### PR TITLE
Add stats collector and CLI flag

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,10 @@
+# Agent Instructions
+
+- Always run the full suite of local checks before creating a pull request:
+  - `ruff check .`
+  - `mypy .`
+  - `pytest -q`
+- Include the output of these commands in the PR description under a **Testing** section.
+- If any command fails due to missing dependencies or other environment issues, note the failure in the **Testing** section rather than omitting it.
+
+These instructions apply to the entire repository.

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -79,10 +79,11 @@ def test_cli_e2e_ingest_extract_weave(runner: CliRunner, test_workspace: Path, t
     assert ext_data[0]['description'] == "E2E test event"
 
     # 4. Weave
-    result_weave = runner.invoke(textura_cli, ['weave', '--workspace', str(test_workspace)])
+    result_weave = runner.invoke(textura_cli, ['weave', '--workspace', str(test_workspace), '--stats'])
     assert result_weave.exit_code == 0
     assert "Wrote 1 items to the vault" in result_weave.output # 1 event
     assert "Building timelines from 1 events" in result_weave.output
+    assert "Textura Run Stats" in result_weave.output
 
     # Verify vault and timeline file creation (basic checks)
     event_notes_path = test_workspace / "vault" / "notes" / "events"

--- a/tests/logging/test_stats_collector.py
+++ b/tests/logging/test_stats_collector.py
@@ -1,0 +1,46 @@
+import json
+from pathlib import Path
+from textura.logging.stats_collector import StatsCollector
+
+
+def create_metacog_log(workspace: Path, entries: list[dict]) -> Path:
+    logs_dir = workspace / "logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    log_file = logs_dir / "metacog.jsonl"
+    with open(log_file, "w", encoding="utf-8") as f:
+        for entry in entries:
+            f.write(json.dumps(entry) + "\n")
+    return log_file
+
+
+def test_stats_collector_counts_extractions_and_errors(tmp_path: Path):
+    entries = [
+        {
+            "validated_extractions": [
+                {"type": "event", "description": "d", "timestamp": "t"}
+            ],
+            "errors": [],
+        },
+        {
+            "validated_extractions": [],
+            "errors": [{"msg": "oops"}],
+        },
+    ]
+    create_metacog_log(tmp_path, entries)
+    collector = StatsCollector(workspace_path=str(tmp_path))
+    stats = collector.collect()
+    assert stats["log_entries"] == 2
+    assert stats["extractions"] == 1
+    assert stats["errors"] == 1
+
+
+def test_stats_collector_summary_format(tmp_path: Path):
+    entries = [
+        {"validated_extractions": [], "errors": []},
+    ]
+    create_metacog_log(tmp_path, entries)
+    collector = StatsCollector(workspace_path=str(tmp_path))
+    summary = collector.format_summary(collector.collect())
+    assert "Textura Run Stats" in summary
+    assert "Log Entries: 1" in summary
+

--- a/textura/cli.py
+++ b/textura/cli.py
@@ -11,6 +11,7 @@ from textura.ingestion.vector_store import FAISSVectorStore
 from textura.extraction.models import ExtractionItem, EventV1, MysteryV1 # Added EventV1, MysteryV1
 from textura.extraction.extractor_agent import ExtractorAgent
 from textura.logging.metacog import Metacog
+from textura.logging.stats_collector import StatsCollector
 from textura.vault.vault_writer import VaultWriter # Added
 from textura.vault.timeline_builder import TimelineBuilder # Added
 
@@ -204,8 +205,9 @@ def extract(workspace: str):
 
 @textura_cli.command() # Changed from placeholder
 @click.option('--workspace', default='textura_workspace', help='Path to the Textura workspace.', show_default=True, required=True, type=click.Path(exists=True))
+@click.option('--stats', is_flag=True, help='Print a run statistics summary based on the metacog log.')
 # Removed --pipeline option for now, as weave is specific to extractions -> vault
-def weave(workspace: str): # Renamed pipeline arg
+def weave(workspace: str, stats: bool): # Renamed pipeline arg
     """Processes extractions, writes them to the vault, and builds timelines."""
     workspace_path = Path(workspace).resolve()
     click.echo(f"Starting weave process for workspace: {workspace_path}")
@@ -277,6 +279,11 @@ def weave(workspace: str): # Renamed pipeline arg
             timeline_builder = TimelineBuilder(workspace_path=str(workspace_path), events=all_events)
             timeline_builder.build_timelines()
             click.echo("Timeline building complete.")
+
+        if stats:
+            collector = StatsCollector(workspace_path=str(workspace_path))
+            summary = collector.format_summary(collector.collect())
+            click.echo(summary)
 
         click.echo("\nWeave process finished.")
 

--- a/textura/logging/stats_collector.py
+++ b/textura/logging/stats_collector.py
@@ -1,0 +1,37 @@
+import json
+from pathlib import Path
+from typing import Dict
+
+
+class StatsCollector:
+    """Collects basic run statistics from the metacog log."""
+
+    def __init__(self, workspace_path: str, log_filename: str = "metacog.jsonl"):
+        self.log_file = Path(workspace_path) / "logs" / log_filename
+
+    def collect(self) -> Dict[str, int]:
+        stats = {"log_entries": 0, "extractions": 0, "errors": 0}
+        if not self.log_file.exists():
+            return stats
+        with open(self.log_file, "r", encoding="utf-8") as f:
+            for line in f:
+                if not line.strip():
+                    continue
+                stats["log_entries"] += 1
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    stats["errors"] += 1
+                    continue
+                stats["extractions"] += len(entry.get("validated_extractions", []))
+                stats["errors"] += len(entry.get("errors", []))
+        return stats
+
+    def format_summary(self, stats: Dict[str, int]) -> str:
+        lines = [
+            "--- Textura Run Stats ---",
+            f"Log Entries: {stats['log_entries']}",
+            f"Validated Extractions: {stats['extractions']}",
+            f"Errors: {stats['errors']}",
+        ]
+        return "\n".join(lines)


### PR DESCRIPTION
## Summary
- implement simple `StatsCollector` for metacog logs
- print stats summary in `textura weave --stats`
- update CLI e2e test to check `--stats`
- add unit tests for stats collector

## Testing
- `ruff check` *(fails: D100, I001, etc.)*
- `mypy .` *(fails: BaseModel subclass errors, etc.)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b4e69a160832595d576035a5458ee